### PR TITLE
use sorted vec and btreemap for dag ir

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "rust-analyzer.check.command": "clippy"
+    "rust-analyzer.check.command": "clippy",
+    "cSpell.words": [
+        "Deque"
+    ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sorted-vec",
  "tempfile",
  "tokio",
  "tracing",
@@ -1685,6 +1686,15 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "sorted-vec"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f64b077cc81ab5f1209bb44c6530a3277261aeaa5405111d48326897306918b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ jq-rs = { version = "0.4" }
 ascii_tree = "0.1"
 # For testing in integration tests
 tempfile = "3"
+sorted-vec = { version = "0.8.5", features = ["serde"] }
 
 [lib]
 name = "baselard"

--- a/examples/serving.rs
+++ b/examples/serving.rs
@@ -111,7 +111,7 @@ async fn execute_dag(
             }
 
             match DAG::from_ir(
-                ir,
+                &ir,
                 &state.registry,
                 dag_config,
                 Some(Arc::clone(&state.cache)),

--- a/src/dag_visualizer.rs
+++ b/src/dag_visualizer.rs
@@ -21,7 +21,7 @@ impl DAGIR {
                 let mut node_map: HashMap<&String, Vec<&String>> = HashMap::new();
 
                 // For each node, look at its dependencies to build parent->child relationships
-                for node in &self.nodes {
+                for node in self.nodes.iter() {
                     if let Some(edges) = self.edges.get(&node.id) {
                         node_map.entry(&node.id).or_default(); // Ensure every node has an entry
                         for edge in edges {
@@ -51,7 +51,7 @@ impl DAGIR {
                 // Build a map of each node to its parents
                 let mut node_map: HashMap<&String, Vec<&String>> = HashMap::new();
 
-                for node in &self.nodes {
+                for node in self.nodes.iter() {
                     node_map.entry(&node.id).or_default();
                     if let Some(edges) = self.edges.get(&node.id) {
                         for edge in edges {

--- a/tests/custom_component_tests.rs
+++ b/tests/custom_component_tests.rs
@@ -70,7 +70,7 @@ async fn test_basic_multiplication() {
     }]);
 
     let dag = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None))
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None))
         .expect("Valid DAG");
 
     let results = dag.execute(None).await.expect("Execution success");
@@ -102,7 +102,7 @@ async fn test_chained_operations() {
     ]);
 
     let dag = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None))
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None))
         .expect("Valid DAG");
 
     let results = dag.execute(None).await.expect("Execution success");
@@ -129,7 +129,7 @@ async fn test_error_handling_config() {
     }]);
 
     let result = DAGIR::from_json(&invalid_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None));
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None));
     assert!(
         result.is_err(),
         "Invalid configuration should return an error"
@@ -147,7 +147,7 @@ async fn test_error_handling_input() {
     }]);
 
     let result = DAGIR::from_json(&invalid_input)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None));
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None));
     assert!(result.is_err(), "Invalid input should return an error");
 }
 
@@ -170,7 +170,7 @@ async fn test_caching_and_replay() {
     let dag = DAGIR::from_json(&json_config)
         .and_then(|ir| {
             DAG::from_ir(
-                ir,
+                &ir,
                 &registry,
                 DAGConfig::default(),
                 Some(Arc::clone(&cache)),
@@ -204,7 +204,7 @@ async fn test_default_input() {
     }]);
 
     let dag = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None))
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None))
         .expect("Valid DAG");
 
     let results = dag.execute(None).await.expect("Execution success");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -68,7 +68,7 @@ async fn test_optimal_makespan() {
     let dag_config = DAGConfig::cache_off();
 
     let start = std::time::Instant::now();
-    let dag = DAG::from_ir(dag_ir, &registry, dag_config, None).expect("Valid DAG");
+    let dag = DAG::from_ir(&dag_ir, &registry, dag_config, None).expect("Valid DAG");
     let results = dag.execute(None).await.expect("Execution success");
     let duration = start.elapsed();
     assert!(
@@ -100,7 +100,7 @@ async fn test_simple_seq_adds_up() {
     let registry = setup_registry();
     let dag_ir = DAGIR::from_json(&json_config).expect("Valid config");
     let dag_config = DAGConfig::cache_off();
-    let dag = DAG::from_ir(dag_ir, &registry, dag_config, None).expect("Valid DAG");
+    let dag = DAG::from_ir(&dag_ir, &registry, dag_config, None).expect("Valid DAG");
     let results = dag.execute(None).await.expect("Execution success");
     assert_eq!(results.len(), 2);
     assert_eq!(
@@ -212,7 +212,7 @@ async fn test_complex_dag_execution() {
         Data::Text("Success!".to_string()),
     );
 
-    match DAG::from_ir(dag_ir, &registry, dag_config, None) {
+    match DAG::from_ir(&dag_ir, &registry, dag_config, None) {
         Ok(dag) => match dag.execute(None).await {
             Ok(results) => {
                 let results_vec: Vec<_> = results.into_iter().collect();
@@ -268,7 +268,7 @@ async fn test_dag_execution_with_errors() {
     let dag_ir = DAGIR::from_json(&json_config).expect("Valid config");
     let dag_config = DAGConfig::cache_off();
 
-    match DAG::from_ir(dag_ir, &registry, dag_config, None) {
+    match DAG::from_ir(&dag_ir, &registry, dag_config, None) {
         Ok(dag) => {
             if let Err(err) = dag.execute(None).await {
                 println!("Execution error: {err}");
@@ -309,7 +309,7 @@ async fn test_dag_execution_with_timeout() {
 
     let dag_ir = DAGIR::from_json(&json_config).expect("Valid config");
 
-    match DAG::from_ir(dag_ir, &registry, dag_config, None) {
+    match DAG::from_ir(&dag_ir, &registry, dag_config, None) {
         Ok(dag) => {
             if let Err(err) = dag.execute(None).await {
                 println!("Execution error: {err}");
@@ -353,7 +353,7 @@ async fn test_dag_cycle_detection() {
     let dag_ir = DAGIR::from_json(&json_config).expect("Valid config");
     let dag_config = DAGConfig::cache_off();
 
-    match DAG::from_ir(dag_ir, &registry, dag_config, None) {
+    match DAG::from_ir(&dag_ir, &registry, dag_config, None) {
         Ok(dag) => match dag.execute(None).await {
             Ok(_) => panic!("Expected cycle detection error"),
             Err(err) => {
@@ -379,7 +379,7 @@ async fn test_dag_empty_graph() {
     let dag_ir = DAGIR::from_json(&json_config).expect("Valid config");
     let dag_config = DAGConfig::cache_off();
 
-    match DAG::from_ir(dag_ir, &registry, dag_config, None) {
+    match DAG::from_ir(&dag_ir, &registry, dag_config, None) {
         Ok(dag) => {
             let result = dag.execute(None).await;
             assert!(result.is_ok(), "Empty DAG should execute successfully");
@@ -406,7 +406,7 @@ async fn test_dag_invalid_component_type() {
     let dag_config = DAGConfig::cache_off();
 
     assert!(
-        DAG::from_ir(dag_ir, &registry, dag_config, None).is_err(),
+        DAG::from_ir(&dag_ir, &registry, dag_config, None).is_err(),
         "Expected error for invalid component type"
     );
 }
@@ -428,7 +428,7 @@ async fn test_dag_invalid_dependency() {
     let dag_config = DAGConfig::cache_off();
 
     assert!(
-        DAG::from_ir(dag_ir, &registry, dag_config, None).is_err(),
+        DAG::from_ir(&dag_ir, &registry, dag_config, None).is_err(),
         "Expected error for invalid dependency"
     );
 }
@@ -456,7 +456,7 @@ async fn test_dag_duplicate_node_ids() {
     let dag_config = DAGConfig::cache_off();
 
     assert!(
-        DAG::from_ir(dag_ir, &registry, dag_config, None).is_err(),
+        DAG::from_ir(&dag_ir, &registry, dag_config, None).is_err(),
         "Expected error for duplicate node IDs"
     );
 }
@@ -523,7 +523,7 @@ async fn test_dag_large_parallel_execution() {
     let dag_ir = DAGIR::from_json(&json_config).expect("Valid config");
     let dag_config = DAGConfig::cache_off();
 
-    match DAG::from_ir(dag_ir, &registry, dag_config, None) {
+    match DAG::from_ir(&dag_ir, &registry, dag_config, None) {
         Ok(dag) => {
             let start = std::time::Instant::now();
             let result = dag.execute(None).await;
@@ -568,7 +568,7 @@ async fn test_dag_cleanup_on_failure() {
     let dag_ir = DAGIR::from_json(&json_config).expect("Valid config");
     let dag_config = DAGConfig::cache_off();
 
-    match DAG::from_ir(dag_ir, &registry, dag_config, None) {
+    match DAG::from_ir(&dag_ir, &registry, dag_config, None) {
         Ok(dag) => {
             let result = dag.execute(None).await;
             assert!(result.is_err(), "Expected execution to fail");
@@ -607,7 +607,7 @@ async fn test_dag_with_caching() {
     let dag_config = DAGConfig::default();
 
     let dag =
-        DAG::from_ir(dag_ir, &registry, dag_config, Some(Arc::clone(&cache))).expect("Valid DAG");
+        DAG::from_ir(&dag_ir, &registry, dag_config, Some(Arc::clone(&cache))).expect("Valid DAG");
 
     let request_id = "test-run-1".to_string();
     let results = dag
@@ -670,7 +670,7 @@ async fn test_dag_replay() {
     let dag_config = DAGConfig::default(); // This enables history
 
     let dag =
-        DAG::from_ir(dag_ir, &registry, dag_config, Some(Arc::clone(&cache))).expect("Valid DAG");
+        DAG::from_ir(&dag_ir, &registry, dag_config, Some(Arc::clone(&cache))).expect("Valid DAG");
 
     // First execution
     let request_id = "replay-test-1".to_string();

--- a/tests/jq_pal_tests.rs
+++ b/tests/jq_pal_tests.rs
@@ -33,7 +33,7 @@ async fn test_basic_transformation() {
     }]);
 
     let dag = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None))
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None))
         .expect("Valid DAG");
 
     let results = dag.execute(None).await.expect("Execution success");
@@ -61,7 +61,7 @@ async fn test_invalid_jq_expression() {
     }]);
 
     let result = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None));
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None));
 
     assert!(
         result.is_err(),
@@ -118,7 +118,7 @@ async fn test_chained_transformations() {
     ]);
 
     let dag = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None))
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None))
         .expect("Valid DAG");
 
     let results = dag.execute(None).await.expect("Execution success");
@@ -151,7 +151,7 @@ async fn test_non_json_input() {
     }]);
 
     let result = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None));
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None));
 
     assert!(result.is_err(), "Non-JSON input should fail DAG validation");
     assert!(
@@ -179,7 +179,7 @@ async fn test_default_identity_transform() {
     }]);
 
     let dag = DAGIR::from_json(&json_config)
-        .and_then(|ir| DAG::from_ir(ir, &registry, DAGConfig::default(), None))
+        .and_then(|ir| DAG::from_ir(&ir, &registry, DAGConfig::default(), None))
         .expect("Valid DAG");
 
     let results = dag.execute(None).await.expect("Execution success");


### PR DESCRIPTION
_These are mostly cosmetic changes as I'm reading and understanding the code. Feel free to close if not interested!_

This PR:
- uses a SortedVec and BTreeMap for nodes and edges in the Dag IR so that we don't need to sort when calculating the hash
- uses a type alias for String, NodeID, to be more clear what's going on in the dag.rs code
- to appease clippy, passes the IR by reference into the DAG

Note, the tests are currently failing on main but I verified that the same 4 tests are failing with this branch, no additional failures.


